### PR TITLE
Update Wreck to 6.x.x and devDependency to Hapi 9.x.x also test on Node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
   - 0.10
-  - 0.12
-  - iojs
+  - 4.0
+  - 4
 
+sudo: false

--- a/package.json
+++ b/package.json
@@ -18,11 +18,12 @@
     "boom": "2.x.x",
     "hoek": "2.x.x",
     "joi": "6.x.x",
-    "wreck": "5.x.x"
+    "wreck": "6.x.x"
   },
   "devDependencies": {
     "code": "1.x.x",
-    "hapi": "8.x.x",
+    "hapi": "9.x.x",
+    "inert": "3.x.x",
     "lab": "5.x.x"
   },
   "scripts": {


### PR DESCRIPTION
Unfortunately test 11 breaks with Hapi 9.

It `merges upstream headers` but the test is expecting:

`X-Custom3,accept-encoding,Something` 

but we are getting:

`X-Custom3,accept-encoding,Something,accept-encoding`

somehow the accept-encoding is put twice while before it was not.