### PR TITLE
Update Wreck dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "boom": "2.x.x",
     "hoek": "2.x.x",
     "joi": "6.x.x",
-    "wreck": "5.x.x"
+    "wreck": "6.x.x"
   },
   "devDependencies": {
     "code": "1.x.x",


### PR DESCRIPTION
Can you please merge this and make a quick last release?

This would really help us, for those of us temporarily stuck on an old Hapi version

1/2 for See #17 