### PR TITLE
Update to Hapi 11, node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 0.10
-  - 0.12
-  - iojs
+  - 4.0
+  - 4
 
+  sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
   - 4.0
   - 4
 
-  sudo: false
+sudo: false

--- a/lib/index.js
+++ b/lib/index.js
@@ -163,7 +163,7 @@ internals.handler = function (route, handlerOptions) {
                     return settings.onResponse.call(bind, null, res, request, reply, settings, ttl);
                 }
 
-                var response = reply(res)
+                return reply(res)
                     .ttl(ttl)
                     .code(res.statusCode)
                     .passThrough(!!settings.passThrough);   // Default to false

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "plugin"
   ],
   "engines": {
-    "node": ">=0.10.32"
+    "node": ">=4.0.0"
   },
   "dependencies": {
     "boom": "2.x.x",
@@ -22,8 +22,9 @@
   },
   "devDependencies": {
     "code": "1.x.x",
-    "hapi": "8.x.x",
-    "lab": "5.x.x"
+    "hapi": "11.x.x",
+    "inert": "3.x.x",
+    "lab": "6.x.x"
   },
   "scripts": {
     "test": "lab -a code -t 100 -L",


### PR DESCRIPTION
So, this might be hard to merge in but it shows some progress to getting h2o2 working. Have to figure out the following two issues. I am lacking time to do so for the next week or two and it's not a priority for work just yet!

You will see 2 things wrong. 

1. Line 125 of lib/index.js: `request.info.remoteAddress` is always true. Have to figure out if that's really true in Hapi 10+ world.

2. Test 10 is broken because CORS has changed a bit in Hapi 11.
```
10) H2o2 overrides upstream cors headers:

      Invalid connection options {
  "compression": true,
  "router": {
    "isCaseSensitive": true,
    "stripTrailingSlash": false
  },
  "routes": {
    "cache": {
      "statuses": [
        200,
        204
      ]
    },
    "cors": {
      "origin": [
        "*"
      ],
      "maxAge": 86400,
      "headers": [
        "Accept",
        "Authorization",
        "Content-Type",
        "If-None-Match"
      ],
      "additionalHeaders": [],
      "exposedHeaders": [
        "WWW-Authenticate",
        "Server-Authorization"
      ],
      "additionalExposedHeaders": [],
      "credentials": true,
      "override" [1]: true
    },
    "files": {
      "relativeTo": "."
    },
    "json": {
      "replacer": null,
      "space": null,
      "suffix": null
    },
    "payload": {
      "failAction": "error",
      "maxBytes": 1048576,
      "output": "data",
      "parse": true,
      "timeout": 10000,
      "uploads": "/var/folders/lv/vwr7g0x97bn0vr72gvsx372m0000gn/T",
      "defaultContentType": "application/json"
    },
    "response": {
      "emptyStatusCode": 200,
      "options": {}
    },
    "security": null,
    "state": {
      "parse": true,
      "failAction": "error"
    },
    "timeout": {
      "server": false
    },
    "validate": {
      "options": {}
    }
  }
}

[1] "override" is not allowed

    "compression": true,
    "router": {
      "isCaseSensitive": true,
      "stripTrailingSlash": false
    },
    "routes": {
      "cache": {
        "statuses": [
          200,
          204
        ]
      },
      "cors": {
        "origin": [
          "*"
        ],
        "maxAge": 86400,
        "headers": [
          "Accept",
          "Authorization",
          "Content-Type",
          "If-None-Match"
        ],
        "additionalHeaders": [],
        "exposedHeaders": [
          "WWW-Authenticate",
          "Server-Authorization"
        ],
        "additionalExposedHeaders": [],
        "credentials": true,
        "override" [1]: true
      },
      "files": {
        "relativeTo": "."
      },
      "json": {
        "replacer": null,
        "space": null,
        "suffix": null
      },
      "payload": {
        "failAction": "error",
        "maxBytes": 1048576,
        "output": "data",
        "parse": true,
        "timeout": 10000,
        "uploads": "/var/folders/lv/vwr7g0x97bn0vr72gvsx372m0000gn/T",
        "defaultContentType": "application/json"
      },
      "response": {
        "emptyStatusCode": 200,
        "options": {}
      },
      "security": null,
      "state": {
        "parse": true,
        "failAction": "error"
      },
      "timeout": {
        "server": false
      },
      "validate": {
        "options": {}
      }
    }
  }
  
  [1] "override" is not allowed
      at Object.exports.assert (/Users/ldesplat/Projects/h2o2/node_modules/hapi/node_modules/hoek/lib/index.js:731:11)
      at Object.exports.apply (/Users/ldesplat/Projects/h2o2/node_modules/hapi/lib/schema.js:15:10)
      at internals.Server.connection (/Users/ldesplat/Projects/h2o2/node_modules/hapi/lib/server.js:117:23)
      at provisionServer (/Users/ldesplat/Projects/h2o2/test/index.js:35:16)
      at /Users/ldesplat/Projects/h2o2/test/index.js:251:26
      at /Users/ldesplat/Projects/h2o2/node_modules/hapi/lib/server.js:276:20
      at internals.Server._invoke (/Users/ldesplat/Projects/h2o2/node_modules/hapi/lib/server.js:344:16)
      at /Users/ldesplat/Projects/h2o2/node_modules/hapi/lib/server.js:268:14
      at done (/Users/ldesplat/Projects/h2o2/node_modules/hapi/node_modules/items/lib/index.js:30:25)
      at Server.finalize (/Users/ldesplat/Projects/h2o2/node_modules/hapi/lib/connection.js:176:9)
      at Server.g (events.js:260:16)
      at emitNone (events.js:72:20)
      at Server.emit (events.js:166:7)
      at emitListeningNT (net.js:1257:10)
      at doNTCallback1 (node.js:419:9)
      at process._tickDomainCallback (node.js:382:17)
```

See #17 for initial PR.