### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,16 +15,16 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "boom": "^3.1.2",
-    "hoek": "^3.0.4",
-    "joi": "^8.0.2",
-    "wreck": "^7.0.0"
+    "boom": "3.X.X",
+    "hoek": "3.X.X",
+    "joi": "8.X.X",
+    "wreck": "7.X.X"
   },
   "devDependencies": {
     "code": "2.X.X",
-    "hapi": "^13.0.0",
+    "hapi": "13.X.X",
     "inert": "3.X.X",
-    "lab": "^9.1.0"
+    "lab": "9.X.X"
   },
   "scripts": {
     "test": "lab -a code -t 100 -L",

--- a/package.json
+++ b/package.json
@@ -15,16 +15,16 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "boom": "2.X.X",
-    "hoek": "2.X.X",
-    "joi": "6.X.X",
-    "wreck": "6.X.X"
+    "boom": "^3.1.2",
+    "hoek": "^3.0.4",
+    "joi": "^8.0.2",
+    "wreck": "^7.0.0"
   },
   "devDependencies": {
     "code": "2.X.X",
-    "hapi": "11.X.X",
+    "hapi": "^13.0.0",
     "inert": "3.X.X",
-    "lab": "7.X.X"
+    "lab": "^9.1.0"
   },
   "scripts": {
     "test": "lab -a code -t 100 -L",

--- a/test/index.js
+++ b/test/index.js
@@ -269,6 +269,7 @@ describe('H2o2', () => {
 
         const onResponse = function (err, res, request, reply, settings, ttl) {
 
+            expect(err).to.be.null();
             reply(res).vary('Something');
         };
 
@@ -340,6 +341,7 @@ describe('H2o2', () => {
 
                 Fs.readFile(__dirname + '/../package.json', { encoding: 'utf8' }, (err, file) => {
 
+                    expect(err).to.be.null();
                     Zlib.unzip(res.rawPayload, (err, unzipped) => {
 
                         expect(err).to.not.exist();
@@ -488,6 +490,7 @@ describe('H2o2', () => {
 
             const onResponseWithError = function (err, res, request, reply, settings, ttl) {
 
+                expect(err).to.be.null();
                 reply(Boom.forbidden('Forbidden'));
             };
 
@@ -510,6 +513,7 @@ describe('H2o2', () => {
 
             const on = function (err, res, request, reply, settings, ttl) {
 
+                expect(err).to.be.null();
                 reply(res).state('a', 'b');
             };
 
@@ -533,6 +537,7 @@ describe('H2o2', () => {
 
             const onResponseWithError = function (err, res, request, reply, settings, ttl) {
 
+                expect(err).to.be.null();
                 reply(this.c);
             };
 
@@ -565,6 +570,7 @@ describe('H2o2', () => {
 
                 const onResponseWithError = function (err, res, request, reply, settings, ttl) {
 
+                    expect(err).to.be.null();
                     reply(this.c);
                 };
 
@@ -609,6 +615,7 @@ describe('H2o2', () => {
 
                 const onResponseWithError = function (err, res, request, reply, settings, ttl) {
 
+                    expect(err).to.be.null();
                     reply(this.c);
                 };
 
@@ -654,6 +661,7 @@ describe('H2o2', () => {
 
                 const onResponseWithError = function (err, res, request, reply, settings, ttl) {
 
+                    expect(err).to.be.null();
                     reply(this.c);
                 };
 
@@ -738,6 +746,7 @@ describe('H2o2', () => {
 
                 Wreck.get('http://127.0.0.1:' + server.info.port + '/', (err, res, body) => {
 
+                    expect(err).to.be.null();
                     expect(res.statusCode).to.equal(200);
                     const result = JSON.parse(body);
 
@@ -788,6 +797,7 @@ describe('H2o2', () => {
 
                 Wreck.get('http://127.0.0.1:' + server.info.port + '/', (err, res, body) => {
 
+                    expect(err).to.be.null();
                     expect(res.statusCode).to.equal(200);
                     const result = JSON.parse(body);
 
@@ -1403,6 +1413,7 @@ describe('H2o2', () => {
 
             const onResponse304 = function (err, res, request, reply, settings, ttl) {
 
+                expect(err).to.be.null();
                 return reply(res).code(304);
             };
 


### PR DESCRIPTION
I've got quite a lot of copies of Wreck in my node_modules folder - this means that a lot of [good](https://github.com/hapijs/good) logging doesn't occur because Wreck is a singleton.

This PR updates all h2o2 dependencies to the latest versions (including Wreck 7) and fixes some linting complaints that code had after the upgrade.

I hope you'll consider merging this, happy to make whatever amends are necessary.