### PR TITLE
Add basic support for request.params in mapUri

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -195,11 +195,17 @@ internals.mapUri = function (protocol, host, port, uri) {
                 return next(null, uri);
             }
 
-            const address = uri.replace(/{protocol}/g, request.connection.info.protocol)
+            let address = uri.replace(/{protocol}/g, request.connection.info.protocol)
                              .replace(/{host}/g, request.connection.info.host)
                              .replace(/{port}/g, request.connection.info.port)
                              .replace(/{path}/g, request.url.path);
 
+            if (request.params){
+                Object.keys(request.params).forEach(function (key) {
+                    let re = new RegExp(`{${key}}`,"g");
+                    address = uri.replace(re,request.params[key]);
+                });
+            }
             return next(null, address);
         };
     }


### PR DESCRIPTION
Make it possible to insert `request.param` values in your custom uri (only meaningful when specifying the `uri` argument in `options`)
```javascript
server.route({ 
    path: '/foo/bar/{image_name}', 
    method:'GET', 
    handler:{
        proxy: {
            uri  : 'https://s3.amazonaws.com/some.random.bucket/folder/{image_name}'
        }
}}),
```

I realize this needs a test added (local testing shows it working) but I may need some help actually writing a good test for the repo.