### PR TITLE
Allow request.params variable replacement in the uri template

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,41 @@ server.route({
     }
 });
 ```
+### Custom `uri` template values
+    
+When using the `uri` option, there are several **default** template values that can be injected from the incoming request:
 
+* `{protocol}`
+* `{host}`
+* `{port}`
+* `{path}`
+    
+```javascript
+server.route({
+    method: 'GET',
+    path: '/',
+    handler: {
+        proxy: {
+            uri: '{protocol}:{port}//{host}/use/the/{path}'
+        }
+    }
+});
+```
+Additionally, you can capture request.params values and inject them into the upstream uri value using a similar replacment strategy:
+```javascript
+server.route({
+    method: 'GET',
+    path: '/foo/{bar}',
+    handler: {
+        proxy: {
+            uri: 'https://some.upstream.service.com/some/path/to/{bar}'
+        }
+    }
+});
+```
+**Note** The default variables of `{protocol}`, `{host}`, `{port}`, `{path}` take precedence - it's best to treat those as reserved when naming your own request.params.
+
+    
 ### Using the `mapUri` and `onResponse` options
 
 Setting both options with custom functions will allow you to map the original request to an upstream service and to processing the response from the upstream service, before sending it to the client. Cannot be used together with `host`, `port`, `protocol`, or `uri`.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ server.route({
 ```
 ### Custom `uri` template values
     
-When using the `uri` option, there are several **default** template values that can be injected from the incoming request:
+When using the `uri` option, there are optional **default** template values that can be injected from the incoming `request`:
 
 * `{protocol}`
 * `{host}`
@@ -136,14 +136,17 @@ When using the `uri` option, there are several **default** template values that 
 ```javascript
 server.route({
     method: 'GET',
-    path: '/',
+    path: '/foo',
     handler: {
         proxy: {
-            uri: '{protocol}:{port}//{host}/use/the/{path}'
+            uri: '{protocol}//{host}:{port}/go/to/{path}'
         }
     }
 });
 ```
+Requests to `http://127.0.0.1:8080/foo/` would be proxied to an upstream destination of `http://127.0.0.1:8080/go/to/foo`
+
+
 Additionally, you can capture request.params values and inject them into the upstream uri value using a similar replacment strategy:
 ```javascript
 server.route({
@@ -156,7 +159,7 @@ server.route({
     }
 });
 ```
-**Note** The default variables of `{protocol}`, `{host}`, `{port}`, `{path}` take precedence - it's best to treat those as reserved when naming your own request.params.
+**Note** The default variables of `{protocol}`, `{host}`, `{port}`, `{path}` take precedence - it's best to treat those as reserved when naming your own `request.params`.
 
     
 ### Using the `mapUri` and `onResponse` options

--- a/lib/index.js
+++ b/lib/index.js
@@ -195,10 +195,16 @@ internals.mapUri = function (protocol, host, port, uri) {
                 return next(null, uri);
             }
 
-            const address = uri.replace(/{protocol}/g, request.connection.info.protocol)
+            let address = uri.replace(/{protocol}/g, request.connection.info.protocol)
                              .replace(/{host}/g, request.connection.info.host)
                              .replace(/{port}/g, request.connection.info.port)
                              .replace(/{path}/g, request.url.path);
+
+            Object.keys(request.params).forEach((key) => {
+
+                const re = new RegExp(`{${key}}`,'g');
+                address = uri.replace(re,request.params[key]);
+            });
 
             return next(null, address);
         };

--- a/test/index.js
+++ b/test/index.js
@@ -1336,6 +1336,33 @@ describe('H2o2', () => {
         });
     });
 
+    it('proxies via uri template with request.param replacement', (done) => {
+
+        const upstream = new Hapi.Server();
+        upstream.connection();
+        upstream.route({
+            method: 'GET',
+            path: '/item/{some_param}',
+            handler: function (request, reply) {
+
+                return reply({ a: request.params['some_param'] });
+            }
+        });
+
+        upstream.start(() => {
+
+            const server = provisionServer();
+            server.route({ method: 'GET', path: '/handlerTemplate/{some_param}', handler: { proxy: { uri: '{protocol}://localhost:' + upstream.info.port + '/item/{some_param}' } } });
+            const some_param = 'foo';
+            server.inject('/handlerTemplate/'+some_param, (res) => {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.payload).to.contain('"a":"'+some_param+'"');
+                done();
+            });
+        });
+    });
+    
     it('passes upstream caching headers', (done) => {
 
         const upstream = new Hapi.Server();

--- a/test/index.js
+++ b/test/index.js
@@ -1336,7 +1336,7 @@ describe('H2o2', () => {
         });
     });
 
-    it('proxies via uri template with request.param replacement', (done) => {
+    it('proxies via uri template with request.param variables', (done) => {
 
         const upstream = new Hapi.Server();
         upstream.connection();
@@ -1345,24 +1345,25 @@ describe('H2o2', () => {
             path: '/item/{some_param}',
             handler: function (request, reply) {
 
-                return reply({ a: request.params['some_param'] });
+                return reply({ a: request.params.some_param });
             }
         });
 
         upstream.start(() => {
 
             const server = provisionServer();
-            server.route({ method: 'GET', path: '/handlerTemplate/{some_param}', handler: { proxy: { uri: '{protocol}://localhost:' + upstream.info.port + '/item/{some_param}' } } });
-            const some_param = 'foo';
-            server.inject('/handlerTemplate/'+some_param, (res) => {
+            server.route({ method: 'GET', path: '/handlerTemplate/{some_param}', handler: { proxy: { uri: 'http://localhost:' + upstream.info.port + '/item/{some_param}' } } });
+
+            const p = 'foo';
+            server.inject('/handlerTemplate/' + p, (res) => {
 
                 expect(res.statusCode).to.equal(200);
-                expect(res.payload).to.contain('"a":"'+some_param+'"');
+                expect(res.payload).to.contain('"a":"' + p + '"');
                 done();
             });
         });
     });
-    
+
     it('passes upstream caching headers', (done) => {
 
         const upstream = new Hapi.Server();


### PR DESCRIPTION
Make it possible to insert `request.params` values in your custom `uri`.  Doesn't clobber any of the previously defined template options: `{protocol}`,`{host}`,`{port}` or `{path}`.

**Usage**
```javascript
server.route({ 
    path: '/foo/bar/{image_name}', 
    method:'GET', 
    handler:{
        proxy: {
            uri  : 'https://s3.amazonaws.com/some.random.bucket/folder/{image_name}'
        }
    }
}),
```
