### PR TITLE
Fix the `uri` vs. `address` variable usage for multiple replacements

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -203,7 +203,7 @@ internals.mapUri = function (protocol, host, port, uri) {
             Object.keys(request.params).forEach((key) => {
 
                 const re = new RegExp(`{${key}}`,'g');
-                address = uri.replace(re,request.params[key]);
+                address = address.replace(re,request.params[key]);
             });
 
             return next(null, address);

--- a/test/index.js
+++ b/test/index.js
@@ -1342,23 +1342,25 @@ describe('H2o2', () => {
         upstream.connection();
         upstream.route({
             method: 'GET',
-            path: '/item/{some_param}',
+            path: '/item/{param_a}/{param_b}',
             handler: function (request, reply) {
 
-                return reply({ a: request.params.some_param });
+                return reply({ a: request.params.param_a, b:request.params.param_b });
             }
         });
 
         upstream.start(() => {
 
             const server = provisionServer();
-            server.route({ method: 'GET', path: '/handlerTemplate/{some_param}', handler: { proxy: { uri: 'http://localhost:' + upstream.info.port + '/item/{some_param}' } } });
+            server.route({ method: 'GET', path: '/handlerTemplate/{a}/{b}', handler: { proxy: { uri: 'http://localhost:' + upstream.info.port + '/item/{a}/{b}' } } });
 
-            const p = 'foo';
-            server.inject('/handlerTemplate/' + p, (res) => {
+            const prma = 'foo';
+            const prmb = 'bar';
+            server.inject(`/handlerTemplate/${prma}/${prmb}`, (res) => {
 
                 expect(res.statusCode).to.equal(200);
-                expect(res.payload).to.contain('"a":"' + p + '"');
+                expect(res.payload).to.contain(`"a":"${prma}"`);
+                expect(res.payload).to.contain(`"b":"${prmb}"`);
                 done();
             });
         });


### PR DESCRIPTION
Also add to to the test to verify that multiple subsequent replacements are cumulative.