### PR TITLE
lowercase `x` in  dependency version strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,16 +15,16 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "boom": "3.X.X",
-    "hoek": "4.X.X",
-    "joi": "9.X.X",
-    "wreck": "9.X.X"
+    "boom": "3.x.x",
+    "hoek": "4.x.x",
+    "joi": "9.x.x",
+    "wreck": "9.x.x"
   },
   "devDependencies": {
-    "code": "3.X.X",
-    "hapi": "14.X.X",
-    "inert": "4.X.X",
-    "lab": "11.X.X"
+    "code": "3.x.x",
+    "hapi": "14.x.x",
+    "inert": "4.x.x",
+    "lab": "11.x.x"
   },
   "scripts": {
     "test": "lab -a code -t 100 -L",


### PR DESCRIPTION
Recently while updating an app to use `yarn` for package management, I noticed that `h2o2` uses capital letter `X` in it's version strings. It seems that the convention is lower case `x` (though `x`, `X`, and `*` are valid semver.

The case mismatch causes yarn to non-deterministically generate `yarn.lock` files, resulting in many diffs such as these:
![image](https://cloud.githubusercontent.com/assets/123745/20441583/c034c976-ad8a-11e6-8a19-b7c0b80144df.png)

This should be addressed in `yarn` as well, and I plan to bring it up, but I figured adjusting to the convention in `h2o2` would be helpful too.