### PR TITLE
Fix onResponse arguments on errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -151,7 +151,7 @@ internals.handler = function (route, handlerOptions) {
         }
         catch (error) {
             if (settings.onResponse) {
-                return settings.onResponse.call(bind, error, res, h, settings, ttl);
+                return settings.onResponse.call(bind, error, res, request, h, settings, ttl);
             }
 
             throw error;

--- a/test/index.js
+++ b/test/index.js
@@ -668,6 +668,7 @@ describe('H2o2', () => {
 
         const failureResponse = function (err, res, request, h, settings, ttl) {
 
+            expect(h.response).to.exist();
             throw err;
         };
 


### PR DESCRIPTION
The `onResponse` method is invoked with the wrong arguments when an error has occurred. Fixed with this PR.