### PR TITLE
Tests for, and closes #63 - xfd headers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -125,9 +125,9 @@ internals.handler = function (route, handlerOptions) {
             request.info.remotePort &&
             request.info.remoteAddress) {
             options.headers['x-forwarded-for'] = (options.headers['x-forwarded-for'] ? options.headers['x-forwarded-for'] + ',' : '') + request.info.remoteAddress;
-            options.headers['x-forwarded-port'] = (options.headers['x-forwarded-port'] ? options.headers['x-forwarded-port'] + ',' : '') + request.info.remotePort;
-            options.headers['x-forwarded-proto'] = (options.headers['x-forwarded-proto'] ? options.headers['x-forwarded-proto'] + ',' : '') + request.server.info.protocol;
-            options.headers['x-forwarded-host'] = (options.headers['x-forwarded-host'] ? options.headers['x-forwarded-host'] + ',' : '') + request.info.host;
+            options.headers['x-forwarded-port'] = options.headers['x-forwarded-port'] ? options.headers['x-forwarded-port'] : request.info.remotePort;
+            options.headers['x-forwarded-proto'] = options.headers['x-forwarded-proto'] ? options.headers['x-forwarded-proto'] : request.server.info.protocol;
+            options.headers['x-forwarded-host'] = options.headers['x-forwarded-host'] ? options.headers['x-forwarded-host'] : request.info.host;
         }
 
         if (settings.ciphers) {

--- a/test/index.js
+++ b/test/index.js
@@ -748,7 +748,7 @@ describe('H2o2', () => {
         await upstream.stop();
     });
 
-    it('adds x-forwarded-* headers to existing', async () => {
+    it('adds x-forwarded-for headers to existing and preserves original port, proto and host', async () => {
 
         const handler = function (request, h) {
 
@@ -784,16 +784,15 @@ describe('H2o2', () => {
         const result = JSON.parse(response.payload);
 
         const expectedClientAddress = '127.0.0.1';
-        const expectedClientAddressAndPort = expectedClientAddress + ':' + server.info.port;
+
         if (Net.isIPv6(server.listener.address().address)) {
             expectedClientAddress = '::ffff:127.0.0.1';
-            expectedClientAddressAndPort = '[' + expectedClientAddress + ']:' + server.info.port;
         }
 
         expect(result['x-forwarded-for']).to.equal('testhost,' + expectedClientAddress);
-        expect(result['x-forwarded-port']).to.match(/1337\,\d+/);
-        expect(result['x-forwarded-proto']).to.equal('https,http');
-        expect(result['x-forwarded-host']).to.equal('example.com,' + expectedClientAddressAndPort);
+        expect(result['x-forwarded-port']).to.equal('1337');
+        expect(result['x-forwarded-proto']).to.equal('https');
+        expect(result['x-forwarded-host']).to.equal('example.com');
 
         await upstream.stop();
         await server.stop();


### PR DESCRIPTION
Breaking if you were dependent on the buggy behavior - the x-forwarded-port, -proto and -host headers were previously lists that h2o2 would append to.  The updated behavior (per conversation in #63) is that we will honor and pass along an existing header or set it based on the request.  x-forwarded-for is the only header where we will append to an existing list.