### PR TITLE
Add Downstream Response Performance Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ const startServer = async function() {
   try {
     await server.register({ plugin: require('h2o2') });
     await server.start();
-    
-    console.log(`Server started at:  ${server.info.uri}`); 
+
+    console.log(`Server started at:  ${server.info.uri}`);
   }
   catch(e) {
     console.log('Failed to load h2o2');
@@ -77,6 +77,7 @@ The proxy handler object has the following properties:
 to force SSL version 3. The possible values depend on your installation of OpenSSL. Read the official OpenSSL docs for possible [SSL_METHODS](http://www.openssl.org/docs/ssl/ssl.html#DEALING_WITH_PROTOCOL_METHODS).
 * `ciphers` - [TLS](https://nodejs.org/api/tls.html#tls_modifying_the_default_tls_cipher_suite) list of TLS ciphers to override node's default.  
 The possible values depend on your installation of OpenSSL. Read the official OpenSSL docs for possible [TLS_CIPHERS](https://www.openssl.org/docs/man1.0.2/apps/ciphers.html#CIPHER-LIST-FORMAT).
+* `downstreamResponseTime` - logs the time spent processing the downstream request using [process.hrtime](https://nodejs.org/api/process.html#process_process_hrtime_time). Defaults to `false`.
 
 ## Usage
 
@@ -133,14 +134,14 @@ server.route({
 });
 ```
 ### Custom `uri` template values
-    
+
 When using the `uri` option, there are optional **default** template values that can be injected from the incoming `request`:
 
 * `{protocol}`
 * `{host}`
 * `{port}`
 * `{path}`
-    
+
 ```javascript
 server.route({
     method: 'GET',
@@ -169,7 +170,7 @@ server.route({
 ```
 **Note** The default variables of `{protocol}`, `{host}`, `{port}`, `{path}` take precedence - it's best to treat those as reserved when naming your own `request.params`.
 
-    
+
 ### Using the `mapUri` and `onResponse` options
 
 Setting both options with custom functions will allow you to map the original request to an upstream service and to processing the response from the upstream service, before sending it to the client. Cannot be used together with `host`, `port`, `protocol`, or `uri`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ const Wreck = require('wreck');
 const internals = {
     agents: {}  // server.info.uri -> { http, https, insecure }
 };
+const NS_PER_SEC = 1e9;
 
 
 internals.defaults = {
@@ -21,7 +22,8 @@ internals.defaults = {
     redirects: false,
     timeout: 1000 * 60 * 3, // Timeout request after 3 minutes
     localStatePassThrough: false,   // Pass cookies defined by the server upstream
-    maxSockets: Infinity
+    maxSockets: Infinity,
+    downstreamResponseTime: false
 };
 
 
@@ -146,21 +148,38 @@ internals.handler = function (route, handlerOptions) {
         let ttl = null;
         let res;
 
+        let downstreamStartTime;
+        if (settings.downstreamResponseTime) {
+            downstreamStartTime = process.hrtime();
+        }
         const promise = Wreck.request(request.method, uri, options);
 
         if (settings.onRequest) {
             settings.onRequest(promise.req);
         }
 
+        let downstreamResponseTime;
         try {
             res = await promise;
+            if (settings.downstreamResponseTime) {
+                downstreamResponseTime = process.hrtime(downstreamStartTime);
+            }
         }
         catch (error) {
+            if (settings.downstreamResponseTime) {
+                downstreamResponseTime = process.hrtime(downstreamStartTime);
+                request.log(['h2o2', 'error'], { downstreamResponseTime: downstreamResponseTime[0] * NS_PER_SEC + downstreamResponseTime[1] });
+            }
             if (settings.onResponse) {
                 return settings.onResponse.call(bind, error, res, request, h, settings, ttl);
             }
 
             throw error;
+        }
+
+        if (settings.downstreamResponseTime) {
+            downstreamResponseTime = process.hrtime(downstreamStartTime);
+            request.log(['h2o2', 'success'], { downstreamResponseTime: downstreamResponseTime[0] * NS_PER_SEC + downstreamResponseTime[1] });
         }
 
         if (settings._upstreamTtl) {


### PR DESCRIPTION
This adds downstream response performance / time tracking to the `request.plugins.good` object so any one can pass this along with the `responseTime` key to various logging endpoints. I was unable to find an example of how to add another key to a `RequestSent` in any hapi/good/h2o2 documentation and this seems most correct.

Test Output:
```
> h2o2@8.0.1 test /Users/matthew/Workspace/h2o2
> lab -a code -t 100 -L


  
  ..................................................
  ..............

64 tests complete
Test duration: 678 ms
Assertions count: 139 (verbosity: 2.17)
No global variable leaks detected
Coverage: 100.00%
Linting results: No issues
```