### PR TITLE
Fix downstreamResponseTime Joi Validation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,8 @@ internals.schema = Joi.object({
     ttl: Joi.string().valid('upstream').allow(null),
     maxSockets: Joi.number().positive().allow(false),
     secureProtocol: Joi.string(),
-    ciphers: Joi.string()
+    ciphers: Joi.string(),
+    downstreamResponseTime: Joi.boolean()
 })
     .xor('host', 'mapUri', 'uri')
     .without('mapUri', 'port')
@@ -179,7 +180,6 @@ internals.handler = function (route, handlerOptions) {
         }
 
         if (settings.downstreamResponseTime) {
-            downstreamResponseTime = process.hrtime(downstreamStartTime);
             request.log(['h2o2', 'success'], { downstreamResponseTime: downstreamResponseTime[0] * NS_PER_SEC + downstreamResponseTime[1] });
         }
 


### PR DESCRIPTION
This adds `downstreamResponseTime` to the `internals.schema` as well as removing an errant duplicate time calculation.