### PR TITLE
This test does not need localStatePassThrough: #87

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1553,8 +1553,7 @@ describe('H2o2', () => {
                 proxy: {
                     host: 'localhost',
                     port: upstream.info.port,
-                    passThrough: true,
-                    localStatePassThrough: true
+                    passThrough: true
                 }
             }
         });


### PR DESCRIPTION
Issue #87 wants an inverse functionality to what is provided by the `localStatePassThrough` setting. But this setting seems like it is not properly tested, because removing it from the tests does not make the test fail.