### PR TITLE
propagate request abortion to upstream server

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -163,9 +163,9 @@ internals.handler = function (route, handlerOptions) {
 
         const promise = settings.httpClient.request(request.method, uri, options);
 
-        request.raw.req.once('aborted', () => {
+        request.events.once('disconnect', () => {
 
-            promise.req.abort();
+            promise.req.destroy();
         });
 
         if (settings.onRequest) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -163,6 +163,11 @@ internals.handler = function (route, handlerOptions) {
 
         const promise = settings.httpClient.request(request.method, uri, options);
 
+        request.raw.req.once('aborted', () => {
+
+            promise.req.abort();
+        });
+
         if (settings.onRequest) {
             settings.onRequest(promise.req);
         }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "@hapi/code": "8.x.x",
     "@hapi/hapi": "20.x.x",
     "@hapi/inert": "6.x.x",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "24.x.x",
+    "@hapi/teamwork": "5.x.x"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",

--- a/test/index.js
+++ b/test/index.js
@@ -1981,10 +1981,7 @@ describe('h2o2', () => {
 
                 inboundRequest.abort();
 
-                return new Promise(() => {
-
-                    return h.response('never resolves');
-                });
+                return Hoek.block();
             }
         });
         await upstream.start();


### PR DESCRIPTION
In our application, we're relying on the request abortion signal to perform cleanup tasks. E.g if a request is aborted, we will cancel the pending async tasks associated with it. 

Currently, `h2o2` does not propagate the cancelation to the upstream server, meaning that using `h2o2` as a proxy in front of the application breaks this whole mechanism. 

This PR addresses the issue by properly canceling the upstream request if/when the inbound request gets canceled.