### PR TITLE
Add querystring support for uri mapping

### DIFF
--- a/API.md
+++ b/API.md
@@ -131,6 +131,7 @@ When using the `uri` option, there are optional **default** template values that
 * `{host}`
 * `{port}`
 * `{path}`
+* `{query}`
 
 ```javascript
 server.route({
@@ -146,19 +147,19 @@ server.route({
 Requests to `http://127.0.0.1:8080/foo/` would be proxied to an upstream destination of `http://127.0.0.1:8080/go/to/foo`
 
 
-Additionally, you can capture request.params values and inject them into the upstream uri value using a similar replacment strategy:
+Additionally, you can capture request.params and query values and inject them into the upstream uri value using a similar replacement strategy:
 ```javascript
 server.route({
     method: 'GET',
     path: '/foo/{bar}',
     handler: {
         proxy: {
-            uri: 'https://some.upstream.service.com/some/path/to/{bar}'
+            uri: 'https://some.upstream.service.com/some/path/to/{bar}{query}'
         }
     }
 });
 ```
-**Note** The default variables of `{protocol}`, `{host}`, `{port}`, `{path}` take precedence - it's best to treat those as reserved when naming your own `request.params`.
+**Note** The default variables of `{protocol}`, `{host}`, `{port}`, `{path}`, `{query}` take precedence - it's best to treat those as reserved when naming your own `request.params`.
 
 
 ### Using the `mapUri` and `onResponse` options

--- a/lib/index.js
+++ b/lib/index.js
@@ -245,7 +245,8 @@ internals.mapUri = function (protocol, host, port, uri) {
             let address = uri.replace(/{protocol}/g, request.server.info.protocol)
                 .replace(/{host}/g, request.server.info.host)
                 .replace(/{port}/g, request.server.info.port)
-                .replace(/{path}/g, request.path);
+                .replace(/{path}/g, request.path)
+                .replace(/{query}/g, request.url.search || '');
 
             Object.keys(request.params).forEach((key) => {
 


### PR DESCRIPTION
Hi,

I found myself in need of transmitting the query string to the proxy target, rather than redefining the mapUri, I thought it would be interesting to add it to the template variables.
If it were to be accepted, I think it would need to be a breaking change, as people could have used `query` inside their params.

Let me know what you think.