### PR TITLE
Support for hapi v21, node v18, ESM tests

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -10,3 +10,6 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-plugin.yml@master
+    with:
+      min-node-version: 14
+      min-hapi-version: 20

--- a/API.md
+++ b/API.md
@@ -13,16 +13,12 @@ const H2o2 = require('@hapi/h2o2');
 const start = async function() {
 
   const server = Hapi.server();
-  try {
-    await server.register(H2o2);
-    await server.start();
 
-    console.log(`Server started at:  ${server.info.uri}`);
-  }
-  catch(e) {
-    console.log('Failed to load h2o2');
-  }
-}
+  await server.register(H2o2);
+  await server.start();
+
+  console.log(`Server started at:  ${server.info.uri}`);
+};
 
 start();
 ```

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2012-2020, Sideway Inc, and project contributors  
-Copyright (c) 2012-2014, Walmart.  
+Copyright (c) 2012-2022, Project contributors
+Copyright (c) 2012-2020, Sideway Inc
+Copyright (c) 2012-2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,9 +64,8 @@ internals.schema = Validate.object({
 exports.plugin = {
     pkg: require('../package.json'),
     requirements: {
-        hapi: '>=19.0.0'
+        hapi: '>=20.0.0'
     },
-
     register: function (server, options) {
 
         internals.defaults = Hoek.applyToDefaults(internals.defaults, options);
@@ -83,7 +82,7 @@ internals.handler = function (route, handlerOptions) {
     const settings = Hoek.applyToDefaults(internals.defaults, handlerOptions, { shallow: ['agent'] });
     Validate.assert(handlerOptions, internals.schema, 'Invalid proxy handler options (' + route.path + ')');
     Hoek.assert(!route.settings.payload || ((route.settings.payload.output === 'data' || route.settings.payload.output === 'stream') && !route.settings.payload.parse), 'Cannot proxy if payload is parsed or if output is not stream or data');
-    settings.mapUri = handlerOptions.mapUri || internals.mapUri(handlerOptions.protocol, handlerOptions.host, handlerOptions.port, handlerOptions.uri);
+    settings.mapUri = handlerOptions.mapUri ?? internals.mapUri(handlerOptions.protocol, handlerOptions.host, handlerOptions.port, handlerOptions.uri);
 
     if (settings.ttl === 'upstream') {
         settings._upstreamTtl = true;
@@ -266,9 +265,9 @@ internals.mapUri = function (protocol, host, port, uri) {
         protocol += ':';
     }
 
-    protocol = protocol || 'http:';
+    protocol = protocol ?? 'http:';
 
-    port = port || (protocol === 'http:' ? 80 : 443);
+    port = port ?? (protocol === 'http:' ? 80 : 443);
     const baseUrl = protocol + '//' + host + ':' + port;
 
     return function (request) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "git://github.com/hapijs/h2o2",
   "main": "lib/index.js",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "files": [
     "lib"
@@ -23,18 +23,18 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x",
-    "@hapi/hoek": "9.x.x",
-    "@hapi/validate": "1.x.x",
-    "@hapi/wreck": "17.x.x"
+    "@hapi/boom": "^10.0.0",
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/validate": "^2.0.0",
+    "@hapi/wreck": "^18.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
-    "@hapi/eslint-plugin": "*",
-    "@hapi/hapi": "20.x.x",
-    "@hapi/inert": "6.x.x",
-    "@hapi/lab": "24.x.x",
-    "@hapi/teamwork": "5.x.x"
+    "@hapi/code": "^9.0.0",
+    "@hapi/eslint-plugin": "^6.0.0",
+    "@hapi/hapi": "^21.0.0-beta.1",
+    "@hapi/inert": "^7.0.0",
+    "@hapi/lab": "^25.0.1",
+    "@hapi/teamwork": "^6.0.0"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let H2o2;
+
+    before(async () => {
+
+        H2o2 = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(H2o2)).to.equal([
+            'default',
+            'plugin'
+        ]);
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -2019,7 +2019,7 @@ describe('h2o2', () => {
         server.route({ method: 'GET', path: '/cancellation', handler: { proxy: { host: 'localhost', port: upstream.info.port } } });
         await server.start();
 
-        const promise = Wreck.request('GET', `http://${server.info.host}:${server.info.port}/cancellation`);
+        const promise = Wreck.request('GET', `http://localhost:${server.info.port}/cancellation`);
         const inboundRequest = promise.req;
 
         await expect(promise).to.reject(/socket hang up/);
@@ -2064,7 +2064,7 @@ describe('h2o2', () => {
         server.route({ method: 'GET', path: '/cancellation', handler: { proxy: { host: 'localhost', port: upstream.info.port } } });
         await server.start();
 
-        const promise = Wreck.request('GET', `http://${server.info.host}:${server.info.port}/cancellation`);
+        const promise = Wreck.request('GET', `http://localhost:${server.info.port}/cancellation`);
         const inboundRequest = promise.req;
 
         const response = await promise;


### PR DESCRIPTION
 - Support and test on hapi v21, drop support for hapi v19.
 - Support and test on node v18, utilize some newer JS syntax.
 - Update all deps for node v18 and hapi v21.
 - Test ESM support.

If this looks good, this will go out as bounce v10 (including #128).