### PR TITLE
Support overriding upstream HTTP method

### DIFF
--- a/API.md
+++ b/API.md
@@ -47,6 +47,7 @@ The proxy handler object has the following properties:
     * `request` - is the incoming [request object](http://hapijs.com/api#request-object). The response from this function should be an       object with the following properties:
         * `uri` - the absolute proxy URI.
         * `headers` - optional object where each key is an HTTP request header and the value is the header content.
+        * `method` - optional HTTP method to use when making request to upstream server.
 * `onRequest` - a custom function which is passed the upstream request.  Function signature is `function (req)` where:
     * `req` - the [wreck] (https://github.com/hapijs/wreck) request to the upstream server.
 * `onResponse` - a custom function for processing the response from the upstream service before sending to the client. Useful for custom error handling of responses from the proxied endpoint or other payload manipulation. Function signature is `function (err, res, request, h, settings, ttl)` where:

--- a/lib/index.js
+++ b/lib/index.js
@@ -92,7 +92,7 @@ internals.handler = function (route, handlerOptions) {
 
     return async function (request, h) {
 
-        const { uri, headers } = await settings.mapUri(request);
+        let { uri, headers, method } = await settings.mapUri(request);
 
         const protocol = uri.split(':', 1)[0];
 
@@ -168,7 +168,8 @@ internals.handler = function (route, handlerOptions) {
             downstreamStartTime = process.hrtime.bigint();
         }
 
-        const promise = settings.httpClient.request(request.method, uri, options);
+        method = method || request.method;
+        const promise = settings.httpClient.request(method, uri, options);
 
         request.events.once('disconnect', () => {
 


### PR DESCRIPTION
I was thinking this can be a useful feature for when you want to replace a legacy API that might only support POST with more RESTful methods via the proxy. I don't know if others will find this valuable or not, so I can go either way on if we want to add it.