### PR TITLE
fix: forward 405 Allow header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -213,10 +213,16 @@ internals.handler = function (route, handlerOptions) {
             return settings.onResponse.call(bind, null, res, request, h, settings, ttl);
         }
 
-        return h.response(res)
+        const response = h.response(res)
             .ttl(ttl)
             .code(res.statusCode)
             .passThrough(!!settings.passThrough);
+
+        if (!settings.passThrough && res.statusCode === 405 && 'allow' in res.headers) {
+            response.header('allow', res.headers.allow);
+        }
+
+        return response;
 
     };
 };


### PR DESCRIPTION
When forwarding 405 errors, it seems that we don't forward the `Allow` header, which is mandatory for this status code (https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405). I think we shouldn't need to set the `passThrough` flag to have this behavior as, without it, it breaks the protocol.